### PR TITLE
Wheel Boy bug fixes

### DIFF
--- a/lua/customroles/wheelboy/cl_wheelboy.lua
+++ b/lua/customroles/wheelboy/cl_wheelboy.lua
@@ -242,19 +242,21 @@ net.Receive("TTT_WheelBoyStartEffect", function()
 
     local effectIdx = net.ReadUInt(4)
     if effectIdx > 0 and effectIdx <= #WHEELBOY.Effects then
-        local result = WHEELBOY.Effects[effectIdx]
-        if result.times == nil then
-            result.times = 0
+        local effect = WHEELBOY.Effects[effectIdx]
+        if effect.times == nil then
+            effect.times = 0
         end
-        result.times = result.times + 1
-        result.start(client, result)
+        effect.times = effect.times + 1
+        effect.start(client, effect)
     end
 end)
 
 net.Receive("TTT_WheelBoyFinishEffect", function()
     local effectIdx = net.ReadUInt(4)
     if effectIdx > 0 and effectIdx <= #WHEELBOY.Effects then
-        WHEELBOY.Effects[effectIdx].finish()
+        local effect = WHEELBOY.Effects[effectIdx]
+        effect.finish()
+        effect.times = 0
     end
 end)
 

--- a/lua/customroles/wheelboy/cl_wheelboy.lua
+++ b/lua/customroles/wheelboy/cl_wheelboy.lua
@@ -150,6 +150,14 @@ net.Receive("TTT_UpdateWheelBoyWins", function()
     }, 1)
 end)
 
+AddHook("TTTPlayerRoleChanged", "WheelBoy_WinTracking_TTTPlayerRoleChanged", function(ply, oldRole, newRole)
+    if not ply:Alive() or ply:IsSpec() then return end
+    if oldRole == newRole then return end
+    if oldRole ~= ROLE_WHEELBOY then return end
+
+    wheelboyWins = false
+end)
+
 local function ResetWheelBoyWin()
     wheelboyWins = false
     ResetWheelState()
@@ -173,13 +181,13 @@ end)
 ------------
 
 AddHook("TTTEventFinishText", "WheelBoy_TTTEventFinishText", function(e)
-    if e.win == WIN_WHEELBOY then
+    if wheelboyWins and e.win == WIN_WHEELBOY then
         return LANG.GetParamTranslation("ev_win_wheelboy", { role = string.lower(ROLE_STRINGS[ROLE_WHEELBOY]) })
     end
 end)
 
 AddHook("TTTEventFinishIconText", "WheelBoy_TTTEventFinishIconText", function(e, win_string, role_string)
-    if e.win == WIN_WHEELBOY then
+    if wheelboyWins and e.win == WIN_WHEELBOY then
         return "ev_win_icon_also", ROLE_STRINGS[ROLE_WHEELBOY]
     end
 end)

--- a/lua/customroles/wheelboy/cl_wheelboy.lua
+++ b/lua/customroles/wheelboy/cl_wheelboy.lua
@@ -181,13 +181,13 @@ end)
 ------------
 
 AddHook("TTTEventFinishText", "WheelBoy_TTTEventFinishText", function(e)
-    if wheelboyWins and e.win == WIN_WHEELBOY then
+    if e.win == WIN_WHEELBOY then
         return LANG.GetParamTranslation("ev_win_wheelboy", { role = string.lower(ROLE_STRINGS[ROLE_WHEELBOY]) })
     end
 end)
 
 AddHook("TTTEventFinishIconText", "WheelBoy_TTTEventFinishIconText", function(e, win_string, role_string)
-    if wheelboyWins and e.win == WIN_WHEELBOY then
+    if e.win == WIN_WHEELBOY then
         return "ev_win_icon_also", ROLE_STRINGS[ROLE_WHEELBOY]
     end
 end)

--- a/lua/customroles/wheelboy/wheelboy.lua
+++ b/lua/customroles/wheelboy/wheelboy.lua
@@ -114,7 +114,7 @@ net.Receive("TTT_WheelBoySpinResult", function(len, ply)
     if effect.times == nil then
         effect.times = 0
     end
-    effect.times = result.times + 1
+    effect.times = effect.times + 1
     effect.start(ply, effect)
     -- If this effect is shared, then send a message to the client so it knows to do something too
     if effect.shared then

--- a/lua/customroles/wheelboy/wheelboy.lua
+++ b/lua/customroles/wheelboy/wheelboy.lua
@@ -90,8 +90,8 @@ net.Receive("TTT_WheelBoySpinResult", function(len, ply)
     if ply:IsRoleAbilityDisabled() then return end
 
     local chosenSegment = net.ReadUInt(4)
-    local result = WHEELBOY.Effects[chosenSegment]
-    if not result then return end
+    local effect = WHEELBOY.Effects[chosenSegment]
+    if not effect then return end
 
     -- If we haven't already won
     if spinCount ~= nil then
@@ -107,17 +107,17 @@ net.Receive("TTT_WheelBoySpinResult", function(len, ply)
 
     -- Let everyone know what the wheel landed on
     for _, p in PlayerIterator() do
-        p:QueueMessage(MSG_PRINTBOTH, ROLE_STRINGS[ROLE_WHEELBOY] .. "'s wheel has landed on '" .. result.name .. "'!")
+        p:QueueMessage(MSG_PRINTBOTH, ROLE_STRINGS[ROLE_WHEELBOY] .. "'s wheel has landed on '" .. effect.name .. "'!")
     end
 
-    -- Run the associated function with the chosen result
-    if result.times == nil then
-        result.times = 0
+    -- Run the associated function with the chosen effect
+    if effect.times == nil then
+        effect.times = 0
     end
-    result.times = result.times + 1
-    result.start(ply, result)
+    effect.times = result.times + 1
+    effect.start(ply, effect)
     -- If this effect is shared, then send a message to the client so it knows to do something too
-    if result.shared then
+    if effect.shared then
         net.Start("TTT_WheelBoyStartEffect")
             net.WriteUInt(chosenSegment, 4)
         net.Broadcast()
@@ -199,6 +199,7 @@ local function ClearEffects()
     -- End all of the effects
     for effectIdx, effect in ipairs(WHEELBOY.Effects) do
         effect.finish()
+        effect.times = 0
 
         -- If this effect is shared, then send a message to the client so it knows to do something too
         if effect.shared then


### PR DESCRIPTION
- Fixed Wheel Boy's spin effect multiplier not resetting each round
- Fixed Wheel Boy still winning if their role is changed before the round ends
- Fixed killed notifications not working for Wheel Boy unless ttt_wheelboy_swap_on_kill was enabled
- Fixed wheel effects not ending when Wheel Boy is killed unless ttt_wheelboy_swap_on_kill was enabled