### PR TITLE
Misc. changes

### DIFF
--- a/lua/customroles/hermit.lua
+++ b/lua/customroles/hermit.lua
@@ -275,6 +275,7 @@ if SERVER then
     AddHook("PlayerDeath", "Hermit_PlayerDeath", function(victim, inflictor, attacker)
         if not IsPlayer(victim) then return end
         if not victim:IsHermit() then return end
+        if victim:IsRoleAbilityDisabled() then return end
 
         local ragdoll = victim.server_ragdoll or victim:GetRagdollEntity()
         if ragdoll then

--- a/lua/customroles/hermit.lua
+++ b/lua/customroles/hermit.lua
@@ -305,6 +305,15 @@ if SERVER then
         net.Broadcast()
     end)
 
+    AddHook("TTTCanRespawnAsRole", "Hermit_PlayerDeath", function(ply, role)
+        if not IsPlayer(ply) then return end
+        if not ply:IsHermit() then return end
+        -- Let them change roles if they aren't going to dissolve
+        if ply:IsRoleAbilityDisabled() then return end
+
+        return false
+    end)
+
     AddHook("TTTDeathNotifyOverride", "Hermit_TTTDeathNotifyOverride", function(victim, inflictor, attacker, reason, killerName, role)
         if GetRoundState() ~= ROUND_ACTIVE then return end
         if not IsValid(inflictor) or not IsValid(attacker) then return end

--- a/lua/customroles/monk.lua
+++ b/lua/customroles/monk.lua
@@ -72,6 +72,15 @@ if SERVER then
         net.Broadcast()
     end)
 
+    AddHook("TTTCanRespawnAsRole", "Monk_PlayerDeath", function(ply, role)
+        if not IsPlayer(ply) then return end
+        if not ply:IsMonk() then return end
+        -- Let them change roles if they aren't going to dissolve
+        if ply:IsRoleAbilityDisabled() then return end
+
+        return false
+    end)
+
     AddHook("TTTDeathNotifyOverride", "Monk_TTTDeathNotifyOverride", function(victim, inflictor, attacker, reason, killerName, role)
         if GetRoundState() ~= ROUND_ACTIVE then return end
         if not IsValid(inflictor) or not IsValid(attacker) then return end

--- a/lua/customroles/zealot.lua
+++ b/lua/customroles/zealot.lua
@@ -79,6 +79,15 @@ if SERVER then
         net.Broadcast()
     end)
 
+    AddHook("TTTCanRespawnAsRole", "Zealot_PlayerDeath", function(ply, role)
+        if not IsPlayer(ply) then return end
+        if not ply:IsZealot() then return end
+        -- Let them change roles if they aren't going to dissolve
+        if ply:IsRoleAbilityDisabled() then return end
+
+        return false
+    end)
+
     AddHook("TTTDeathNotifyOverride", "Zealot_TTTDeathNotifyOverride", function(victim, inflictor, attacker, reason, killerName, role)
         if GetRoundState() ~= ROUND_ACTIVE then return end
         if not IsValid(inflictor) or not IsValid(attacker) then return end

--- a/lua/customroles/zealot.lua
+++ b/lua/customroles/zealot.lua
@@ -35,7 +35,7 @@ end
 
 ROLE.translations = {
     ["english"] = {
-        ["ev_zealot_killed"] = "The {zealot} ({ply}) died and became a ghost"
+        ["ev_zealot_died"] = "The {zealot} ({ply}) died and became a ghost"
     }
 }
 


### PR DESCRIPTION
- Fixed typo causing missing Zealot death event translation
- Changed Hermit to not get ghostly powers when their role is disabled (like the other roles)
- Added support for future logic which disables hermit, monk, and zealot from respawning as a different role (zombie, hive mind)