### PR TITLE
Role registration bug fixes

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1355,6 +1355,7 @@ globals = {
     "TASKMASTER",
 
     -- JJ2023
+    "ROLE_GHOSTWHISPERER",
     "ROLE_SOULBOUND",
 
     -- JJ2024

--- a/lua/customroles/hermit.lua
+++ b/lua/customroles/hermit.lua
@@ -565,11 +565,11 @@ if CLIENT then
     }
 end
 
-local function Hermit_TTTRoleSpawnsArtificially(role)
+AddHook("TTTRoleSpawnsArtificially", "Hermit_TTTRoleSpawnsArtificially", function(role)
     if role == ROLE_HERMIT and util.CanRoleSpawn(ROLE_MISSIONARY) then
         return true
     end
-end
+end)
 
 AddHook("TTTUpdateRoleState", "Hermit_TTTUpdateRoleState", function()
     if INNOCENT_ROLES[ROLE_HERMIT] or TRAITOR_ROLES[ROLE_HERMIT] then return end
@@ -583,6 +583,6 @@ end)
 -- REGISTRATION --
 ------------------
 
-ROLE.registeredhooks["TTTRoleSpawnsArtificially"] = Hermit_TTTRoleSpawnsArtificially
+ROLE.hookregistrationdependencies = {ROLE_SOULBOUND, ROLE_GHOSTWHISPERER}
 
 RegisterRole(ROLE)

--- a/lua/customroles/monk.lua
+++ b/lua/customroles/monk.lua
@@ -151,27 +151,18 @@ if CLIENT then
 
         return html
     end)
-
-    ------------------
-    -- REGISTRATION --
-    ------------------
-
-    ROLE.registeredhooks = {
-        -- Create an empty table here so any hooks in a shared context can be added to it below
-        -- If no hooks are registered in a shared context, this block can be removed
-    }
 end
 
-local function Monk_TTTRoleSpawnsArtificially(role)
+AddHook("TTTRoleSpawnsArtificially", "Monk_TTTRoleSpawnsArtificially", function(role)
     if role == ROLE_MONK and util.CanRoleSpawn(ROLE_MISSIONARY) then
         return true
     end
-end
+end)
 
 ------------------
 -- REGISTRATION --
 ------------------
 
-ROLE.registeredhooks["TTTRoleSpawnsArtificially"] = Monk_TTTRoleSpawnsArtificially
+ROLE.hookregistrationdependencies = {ROLE_SOULBOUND, ROLE_GHOSTWHISPERER}
 
 RegisterRole(ROLE)

--- a/lua/customroles/zealot.lua
+++ b/lua/customroles/zealot.lua
@@ -196,4 +196,10 @@ AddHook("TTTRoleSpawnsArtificially", "Zealot_TTTRoleSpawnsArtificially", functio
     end
 end)
 
+------------------
+-- REGISTRATION --
+------------------
+
+ROLE.hookregistrationdependencies = {ROLE_SOULBOUND, ROLE_GHOSTWHISPERER}
+
 RegisterRole(ROLE)

--- a/lua/customroles/zealot.lua
+++ b/lua/customroles/zealot.lua
@@ -190,16 +190,10 @@ if CLIENT then
     }
 end
 
-local function Zealot_TTTRoleSpawnsArtificially(role)
+AddHook("TTTRoleSpawnsArtificially", "Zealot_TTTRoleSpawnsArtificially", function(role)
     if role == ROLE_ZEALOT and util.CanRoleSpawn(ROLE_MISSIONARY) then
         return true
     end
-end
-
-------------------
--- REGISTRATION --
-------------------
-
-ROLE.registeredhooks["TTTRoleSpawnsArtificially"] = Zealot_TTTRoleSpawnsArtificially
+end)
 
 RegisterRole(ROLE)


### PR DESCRIPTION
- Fixed util.CanRoleSpawnArtificially for Hermit, Monk, and Zealot
- Fixed innocent Hermit not getting Ghostwhisperer's abilties when dead
- Fixed Monk and Zealot not getting Ghostwhisperer's abilities when dead